### PR TITLE
nav-docs.svelte: sidebar closed on 'tip->click+mobile' event

### DIFF
--- a/src/lib/components/nav-docs.svelte
+++ b/src/lib/components/nav-docs.svelte
@@ -15,6 +15,7 @@
 
   const tipsTitle = "Tips";
   const tipsUrl = resolve("/tips");
+  const sidebar = Sidebar.useSidebar();
 </script>
 
 <Sidebar.Group>
@@ -49,7 +50,11 @@
                   <Sidebar.MenuSubItem>
                     <Sidebar.MenuSubButton>
                       {#snippet child({ props })}
-                        <a href={link.href} {...props}>
+                        <a
+                          href={link.href}
+                          onclick={() => sidebar.setOpenMobile(false)}
+                          {...props}
+                        >
                           <span>{link.name}</span>
                         </a>
                       {/snippet}


### PR DESCRIPTION
It's fixed: `onclick={() => sidebar.setOpenMobile(false)}` configured