### PR TITLE
pnpm.yaml: dart-sass no longer installed (not needed)

### DIFF
--- a/.github/workflows/pnpm.yaml
+++ b/.github/workflows/pnpm.yaml
@@ -23,7 +23,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DART_SASS_VERSION: 1.89.2
       HUGO_VERSION: 0.148.1
       HUGO_ENVIRONMENT: production
       TZ: UTC
@@ -32,12 +31,6 @@ jobs:
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
           sudo dpkg -i ${{ runner.temp }}/hugo.deb
-      - name: Install Dart Sass
-        run: |
-          wget -O ${{ runner.temp }}/dart-sass.tar.gz https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz
-          tar -xf ${{ runner.temp }}/dart-sass.tar.gz --directory ${{ runner.temp }}
-          mv ${{ runner.temp }}/dart-sass/ /usr/local/bin
-          echo "/usr/local/bin/dart-sass" >> $GITHUB_PATH
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
PNPM workflow manually triggered after https://github.com/sfmunoz/sfmunoz.github.io/commit/a06edd6a8f3b96db30d8ccefed7d3f17a17345dd push to branch:

- build worked fine without dart-sass
- deploy failed because of a lack of permission (as expected)

So everything is ok